### PR TITLE
fix: updates arcgis-map css styling

### DIFF
--- a/app-dashboard-2/style.css
+++ b/app-dashboard-2/style.css
@@ -57,12 +57,9 @@ body.calcite-mode-dark {
 /* Demo template supporting styles */
 
 html,
-body,
-arcgis-map {
-  padding: 0;
+body {
   margin: 0;
   height: 100%;
-  width: 100%;
 }
 
 calcite-menu-item {

--- a/app-dashboard/style.css
+++ b/app-dashboard/style.css
@@ -2,12 +2,9 @@
 /* Demo template supporting styles */
 
 html,
-body,
-arcgis-map {
-  padding: 0;
+body {
   margin: 0;
   height: 100%;
-  width: 100%;
 }
 
 calcite-menu-item {

--- a/app-map-2/style.css
+++ b/app-map-2/style.css
@@ -57,12 +57,9 @@ body.calcite-mode-dark {
 /* Demo template supporting styles */
 
 html,
-body,
-arcgis-map {
-  padding: 0;
+body {
   margin: 0;
   height: 100%;
-  width: 100%;
 }
 
 calcite-menu-item {

--- a/app-map/style.css
+++ b/app-map/style.css
@@ -2,12 +2,9 @@
 /* Demo template supporting styles */
 
 html,
-body,
-arcgis-map {
-  padding: 0;
+body {
   margin: 0;
   height: 100%;
-  width: 100%;
 }
 
 calcite-menu-item {

--- a/app-showcase-frame/style.css
+++ b/app-showcase-frame/style.css
@@ -2,12 +2,9 @@
 /* Demo template supporting styles */
 
 html,
-body,
-arcgis-map {
-  padding: 0;
+body {
   margin: 0;
   height: 100%;
-  width: 100%;
 }
 
 calcite-menu-item {

--- a/shell-slots/style.css
+++ b/shell-slots/style.css
@@ -2,12 +2,9 @@
 /* Demo template supporting styles */
 
 html,
-body,
-arcgis-map {
-  padding: 0;
+body {
   margin: 0;
   height: 100%;
-  width: 100%;
 }
 
 calcite-navigation-logo {


### PR DESCRIPTION
### Summary
Updates css references for `arcgis-map` in alignment with our story for DTS

Via Max on [Teams](https://teams.microsoft.com/l/message/19:be440da908984fc3bfe7c7d9b3deb919@thread.skype/1740634180546?tenantId=aee6e3c9-711e-4c7c-bd27-04f2307db20d&groupId=30b31ec5-c158-4a79-9db7-80cefdec97a1&parentMessageId=1730493889070&teamName=JSAPI%20team%20(internal)&channelName=Documentation&createdTime=1740634180546):

> ...can be simplified a bit in 4.32 (display:block is now the default - no longer need it explicitly: 

```html
<style>
    html,
    body {
      height: 100%;
      margin: 0;
    }
  </style>
```