### PR TITLE
Bump CC + JSAPI versions, related css property changes

### DIFF
--- a/app-dashboard-2/index.html
+++ b/app-dashboard-2/index.html
@@ -7,13 +7,13 @@
   <title>2025 Esri Developer & Technology Summit - Designing Apps with Calcite Design System</title>
 
   <!-- Calcite import -->
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"></script>
 
   <!-- ArcGIS Maps SDK for JavaScript imports -->
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script src="https://js.arcgis.com/4.33/"></script>
+  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/light/main.css" />
+  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/dark/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.33/arcgis-map-components.esm.js"></script>
 
   <!-- Demo imports -->
   <script src="./app.js" defer></script>

--- a/app-dashboard-2/style.css
+++ b/app-dashboard-2/style.css
@@ -25,6 +25,7 @@ body {
   --calcite-color-border-2: #e8e1dc;
   --calcite-color-border-3: #e6ddd1;
   --calcite-color-border-input: #a1a19e;
+  --calcite-color-focus: var(--calcite-brand-color);
 }
 
 body.calcite-mode-dark {
@@ -51,6 +52,7 @@ body.calcite-mode-dark {
   --calcite-color-border-2: #40383a;
   --calcite-color-border-3: #47423e;
   --calcite-color-border-input: #4b4245;
+  --calcite-color-focus: var(--calcite-brand-color);
 }
 
 /* Esri Developer & Technology Summit Demo Template */

--- a/app-dashboard/index.html
+++ b/app-dashboard/index.html
@@ -7,13 +7,13 @@
   <title>2025 Esri Developer & Technology Summit - Designing Apps with Calcite Design System</title>
 
   <!-- Calcite import -->
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"></script>
 
   <!-- ArcGIS Maps SDK for JavaScript imports -->
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script src="https://js.arcgis.com/4.33/"></script>
+  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/light/main.css" />
+  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/dark/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.33/arcgis-map-components.esm.js"></script>
 
   <!-- Demo imports -->
   <script src="./app.js" defer></script>

--- a/app-map-2/index.html
+++ b/app-map-2/index.html
@@ -7,13 +7,13 @@
   <title>2025 Esri Developer & Technology Summit - Designing Apps with Calcite Design System</title>
 
   <!-- Calcite import -->
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"></script>
 
   <!-- ArcGIS Maps SDK for JavaScript imports -->
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script src="https://js.arcgis.com/4.33/"></script>
+  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/light/main.css" />
+  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/dark/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.33/arcgis-map-components.esm.js"></script>
 
   <!-- Demo imports -->
   <script src="./app.js" defer></script>

--- a/app-map-2/style.css
+++ b/app-map-2/style.css
@@ -25,6 +25,7 @@ body {
   --calcite-color-border-2: #cdd4d0;
   --calcite-color-border-3: #dfe8e3;
   --calcite-color-border-input: #727d77;
+  --calcite-color-focus: var(--calcite-brand-color);
 }
 
 body.calcite-mode-dark {
@@ -51,6 +52,7 @@ body.calcite-mode-dark {
   --calcite-color-border-2: #39473f;
   --calcite-color-border-3: #2b3d33;
   --calcite-color-border-input: rgb(80, 87, 83);
+  --calcite-color-focus: var(--calcite-brand-color);
 }
 
 /* Esri Developer & Technology Summit Demo Template */

--- a/app-map/index.html
+++ b/app-map/index.html
@@ -7,13 +7,13 @@
   <title>2025 Esri Developer & Technology Summit - Designing Apps with Calcite Design System</title>
 
   <!-- Calcite import -->
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"></script>
 
   <!-- ArcGIS Maps SDK for JavaScript imports -->
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script src="https://js.arcgis.com/4.33/"></script>
+  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/light/main.css" />
+  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/dark/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.33/arcgis-map-components.esm.js"></script>
 
   <!-- Demo imports -->
   <script src="./app.js" defer></script>

--- a/app-showcase-frame/index.html
+++ b/app-showcase-frame/index.html
@@ -7,12 +7,12 @@
   <title>2025 Esri Developer & Technology Summit - Designing Apps with Calcite Design System</title>
 
   <!-- Calcite import -->
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"></script>
 
   <!-- ArcGIS Maps SDK for JavaScript imports -->
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script src="https://js.arcgis.com/4.33/"></script>
+  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/dark/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.33/arcgis-map-components.esm.js"></script>
 
   <!-- Demo imports -->
   <script src="./app.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -6,14 +6,13 @@
   <title>2025 Esri Developer & Technology Summit - Designing Apps with Calcite Design System</title>
 
   <!-- Calcite import -->
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"></script>
 
   <!-- ArcGIS Maps SDK for JavaScript imports -->
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link id="jsapi-mode-light" rel="stylesheet"
-    href="https://js.arcgis.com/4.32/@arcgis/core/assets/esri/themes/light/main.css" />
-  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script src="https://js.arcgis.com/4.33/"></script>
+  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/light/main.css" />
+  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/dark/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.33/arcgis-map-components.esm.js"></script>
 
   <!-- Demo imports -->
   <script src="./app.js" defer></script>

--- a/shell-slots/index.html
+++ b/shell-slots/index.html
@@ -7,14 +7,13 @@
   <title>2025 Esri Developer & Technology Summit - Designing Apps with Calcite Design System</title>
 
   <!-- Calcite import -->
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"></script>
 
   <!-- ArcGIS Maps SDK for JavaScript imports -->
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link id="jsapi-mode-light" rel="stylesheet"
-    href="https://js.arcgis.com/4.32/@arcgis/core/assets/esri/themes/light/main.css" />
-  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script src="https://js.arcgis.com/4.33/"></script>
+  <link id="jsapi-mode-light" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/light/main.css" />
+  <link disabled id="jsapi-mode-dark" rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/dark/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.33/arcgis-map-components.esm.js"></script>
 
   <!-- Demo imports -->
   <link rel="stylesheet" href="./style.css" />


### PR DESCRIPTION
Updates CC to 3.2.1, JSAPI to 4.33. Adds `--calcite-color-focus` css var in themed samples.